### PR TITLE
tweak generator closing

### DIFF
--- a/conda_package_streaming/url.py
+++ b/conda_package_streaming/url.py
@@ -39,7 +39,7 @@ def extract_conda_info(url, destdir, checklist=METADATA_CHECKLIST, session=sessi
             checklist.remove(member.name)
         if not checklist:
             stream.close()
-            break
+            # next iteration of for loop raises GeneratorExit in stream
 
 
 def stream_conda_info(url, session=session):

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -33,9 +33,10 @@ def test_stream_s3(s3_client, conda_paths):
     for path in conda_paths[:LIMIT]:
         members = s3.stream_conda_info(s3_client, "pkgs", path.name)
         print("stream s3", path.name)
+        found = False
         for tar, member in members:
             if member.name == "info/index.json":
+                found = True
                 members.close()  # faster than waiting for gc?
-                break
-        else:
+        if not found:
             pytest.fail("info/index.json not found")


### PR DESCRIPTION
This change is intended to cause `tar_generator`'s `with:` block to close the tarfile. However it's uncertain whether this actually cleans up resources more quickly; tarfile with fileobj passed in doesn't close its file. Difficult to test these cleanups.