### PR TITLE
add Callable[] annotations to transmute

### DIFF
--- a/conda_package_streaming/transmute.py
+++ b/conda_package_streaming/transmute.py
@@ -11,11 +11,14 @@ Conda packages created this way will also have `info-*` as the last element in
 the `ZipFile`, instead of the first for normal conda packages.
 """
 
+from __future__ import annotations
+
 import io
 import json
 import os
 import tarfile
 import zipfile
+from typing import Callable
 
 import zstandard
 
@@ -32,10 +35,12 @@ def transmute(
     package,
     path,
     *,
-    compressor=lambda: zstandard.ZstdCompressor(
+    compressor: Callable[
+        [], zstandard.ZstdCompressor
+    ] = lambda: zstandard.ZstdCompressor(
         level=ZSTD_COMPRESS_LEVEL, threads=ZSTD_COMPRESS_THREADS
     ),
-    is_info=lambda filename: filename.startswith("info/"),
+    is_info: Callable[[str], bool] = lambda filename: filename.startswith("info/"),
 ):
     """
     Convert .tar.bz2 conda :package to .conda-format under path.


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Makes sphinx documentation look like this, with tilde ~ prefixes?

`conda_package_streaming.transmute.transmute(package, path, *, compressor: ~typing.Callable[[], ~zstd.ZstdCompressor] = <function <lambda>>, is_info=<function <lambda>>)`

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
