### PR TITLE
Tests require conda, note that

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ test = [
   "boto3",
   "boto3-stubs[essential]",
   "bottle",
+  "conda",
 ]
 docs = ["furo", "sphinx", "myst-parser", "mdit-py-plugins>=0.3.0"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ pytest-mock
 boto3
 boto3-stubs[essential]
 bottle
+conda
 # docs
 furo
 sphinx


### PR DESCRIPTION
### Description

While packaging this for Fedora (https://bugzilla.redhat.com/show_bug.cgi?id=2150574) we've noted that the tests seem to require conda.

An alternative I suppose would be for https://github.com/conda/conda-package-streaming/blob/9c5dba578f0a2fe47f52ac02218483763a720744/tests/server.py#L24 to handle CONDA_EXE not being set more gracefully and skipping the tests that require it.

Also, is `boto3-stubs[essential]` really required?