### PR TITLE
Respect umask

### DIFF
--- a/conda_package_streaming/package_streaming.py
+++ b/conda_package_streaming/package_streaming.py
@@ -14,8 +14,8 @@ from typing import Generator
 
 # acquire umask taking advantage of import system lock, instead of possibly in
 # multiple threads at once.
-umask = os.umask(0)
-os.umask(umask)
+UMASK = os.umask(0)
+os.umask(UMASK)
 
 try:
     import zstandard
@@ -36,7 +36,7 @@ class CondaComponent(Enum):
 
 
 class TarfileNoSameOwner(tarfile.TarFile):
-    def __init__(self, *args, umask=umask, **kwargs):
+    def __init__(self, *args, umask=UMASK, **kwargs):
         """Open an (uncompressed) tar archive `name'. `mode' is either 'r' to
         read from an existing archive, 'a' to append data to an existing
         file or 'w' to create a new file overwriting an existing one. `mode'

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -121,7 +121,7 @@ def test_umask(tmp_path, mocker):
 
     Mock umask in case it is different on your system.
     """
-    mocker.patch("conda_package_streaming.package_streaming.umask", new=0o22)
+    mocker.patch("conda_package_streaming.package_streaming.UMASK", new=0o22)
 
     tar3 = empty_tarfile(name="naughty_umask", mode=0o777)
     extract.extract_stream(stream_stdlib(tar3), tmp_path)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This extends tarfile to apply umask (before ever creating the file with tar's default chown).

This should work if the program does not change its own umask. It is probably necessary to check umask with a global lock such as the one used by module level globals in the import system for thread safety.

Resolves https://github.com/conda/conda/issues/12829