### PR TITLE
Force ZIP64 streams

### DIFF
--- a/conda_package_streaming/transmute.py
+++ b/conda_package_streaming/transmute.py
@@ -103,14 +103,14 @@ def transmute(
             conda_file.writestr("metadata.json", json.dumps(pkg_metadata))
 
             with conda_file.open(
-                f"pkg-{file_id}.tar.zst", "w"
+                f"pkg-{file_id}.tar.zst", "w", force_zip64=True
             ) as pkg_file_zip, data_compress.stream_writer(
                 pkg_file_zip, size=pkg_size, closefd=False
             ) as pkg_stream:
                 shutil.copyfileobj(pkg_file._file, pkg_stream)
 
             with conda_file.open(
-                f"info-{file_id}.tar.zst", "w"
+                f"info-{file_id}.tar.zst", "w", force_zip64=True
             ) as info_file_zip, data_compress.stream_writer(
                 info_file_zip, size=info_size, closefd=False
             ) as info_stream:


### PR DESCRIPTION
If the archive stream is >2GB, currently the conversion will fail because while the `conda_file` object will support ZIP64 by default, `open` still requires an explicit call when the input file size is unknown.

### Description

Prior to this change, if trying to convert an archive which exceeds 2GB (see a few packagesfrom the deep learning space), the conversion will fail with a message like:

```
failed files:
{'input.tar.bz2': 'File size unexpectedly exceeded ZIP64 limit'}
```

This ensures that the output stream is written as ZIP64 and the 2GB barrier isn't encountered for the archive contents.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
