### PR TITLE
use zip64 extensions; 100% code coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 [//]: # (current developments)
 
+## 0.10.0 (2024-05)
+* Use zip64 extensions when converting .tar.bz2 to .conda, if uncompressed size
+  is close to the 2GB ZIP64_LIMIT. (#79)
+
 ## 0.9.0 (2023-07)
 
 * Respect umask when extracting files. [#65](https://github.com/conda/conda-package-streaming/pulls/65); [conda issue #12829](https://github.com/conda/conda/issues/12829).

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -50,15 +50,3 @@ def test_chmod_error(tmp_path, mocker):
             tmp_path / "test.tar", errorlevel=2
         ) as tar:
             tar.extractall(tmp_path)
-
-
-# class TarfileNoSameOwner(tarfile.TarFile):
-#     def chmod(self, tarinfo, targetpath):
-#         """
-#         Set file permissions of targetpath according to tarinfo, respecting
-#         umask.
-#         """
-#         try:
-#             os.chmod(targetpath, tarinfo.mode & (0o777 - self.umask))
-#         except OSError as e:
-#             raise tarfile.ExtractError("could not change mode") from e

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,4 +1,6 @@
+import io
 import json
+import tarfile
 
 import pytest
 
@@ -31,3 +33,32 @@ def test_early_exit(conda_paths):
         # stream_conda_info doesn't close a passed-in fileobj, but a
         # filename should be closed.
         assert found, f"index.json not found in {package}"
+
+
+def test_chmod_error(tmp_path, mocker):
+    """
+    Coverage for os.chmod() error handling.
+    """
+    with package_streaming.TarfileNoSameOwner(tmp_path / "test.tar", mode="w") as tar:
+        member = tarfile.TarInfo(name="file")
+        tar.addfile(member, io.BytesIO())
+
+    mocker.patch("os.chmod", side_effect=OSError)
+    with pytest.raises(tarfile.ExtractError):
+        # only logs a debug message if errorlevel<=1
+        with package_streaming.TarfileNoSameOwner(
+            tmp_path / "test.tar", errorlevel=2
+        ) as tar:
+            tar.extractall(tmp_path)
+
+
+# class TarfileNoSameOwner(tarfile.TarFile):
+#     def chmod(self, tarinfo, targetpath):
+#         """
+#         Set file permissions of targetpath according to tarinfo, respecting
+#         umask.
+#         """
+#         try:
+#             os.chmod(targetpath, tarinfo.mode & (0o777 - self.umask))
+#         except OSError as e:
+#             raise tarfile.ExtractError("could not change mode") from e


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Like #71 

Cautiously only use zip64 if uncompressed size is close to limit, based on compression growth tests zstd-compressing /dev/urandom

Complete 100% code coverage of conda_package_streaming/*

Fixes #79 

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
