### PR TITLE
filter subdir out of filename when finding .conda component files

### DIFF
--- a/conda_package_streaming/package_streaming.py
+++ b/conda_package_streaming/package_streaming.py
@@ -131,7 +131,7 @@ def stream_conda_component(
         file_id = re.sub("^(osx|linux|win|noarch)(-.+?)?_", "", file_id)
         component_name = f"{component}-{file_id}"
         component_filename = [
-            info for info in zf.infolist() if component_name in info.filename
+            info for info in zf.infolist() if info.filename.startswith(component_name)
         ]
         if not component_filename:
             raise LookupError(f"didn't find {component_name} component in {filename}")

--- a/conda_package_streaming/package_streaming.py
+++ b/conda_package_streaming/package_streaming.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import bz2
 import os
 import os.path
+import re
 import tarfile
 import zipfile
 from enum import Enum
@@ -125,9 +126,12 @@ def stream_conda_component(
 
         zf = zipfile.ZipFile(fileobj or filename)
         file_id, _, _ = os.path.basename(filename).rpartition(".")
+        # this substitution compensates for web downloads from anaconda.org having
+        # the platform as a prefix
+        file_id = re.sub("^(osx|linux|win)-.+?_", "", file_id)
         component_name = f"{component}-{file_id}"
         component_filename = [
-            info for info in zf.infolist() if info.filename.startswith(component_name)
+            info for info in zf.infolist() if component_name in info.filename
         ]
         if not component_filename:
             raise LookupError(f"didn't find {component_name} component in {filename}")

--- a/conda_package_streaming/package_streaming.py
+++ b/conda_package_streaming/package_streaming.py
@@ -128,7 +128,7 @@ def stream_conda_component(
         file_id, _, _ = os.path.basename(filename).rpartition(".")
         # this substitution compensates for web downloads from anaconda.org having
         # the platform as a prefix
-        file_id = re.sub("^(osx|linux|win)-.+?_", "", file_id)
+        file_id = re.sub("^(osx|linux|win|noarch)(-.+?)?_", "", file_id)
         component_name = f"{component}-{file_id}"
         component_filename = [
             info for info in zf.infolist() if component_name in info.filename

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -14,10 +14,11 @@ def test_package_streaming_with_subdir_prefix(conda_paths, tmp_path, subdir):
     """Regression test for https://github.com/conda/conda-package-handling/issues/230"""
     for path in conda_paths:
         copied_file = tmp_path / f"{subdir}_{os.path.basename(path)}"
-        shutil.copyfile(path, copied_file )
+        shutil.copyfile(path, copied_file)
 
         if str(path).endswith(".conda"):
             package_streaming.stream_conda_component(copied_file, component="info")
+
 
 def test_package_streaming(conda_paths):
     for path in conda_paths:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,11 +1,23 @@
 import io
 import json
+import os
+import shutil
 import tarfile
 
 import pytest
 
 from conda_package_streaming import package_streaming
 
+
+@pytest.mark.parametrize("subdir", ["linux-64", "noarch", "win-32", "osx-arm64"])
+def test_package_streaming_with_subdir_prefix(conda_paths, tmp_path, subdir):
+    """Regression test for https://github.com/conda/conda-package-handling/issues/230"""
+    for path in conda_paths:
+        copied_file = tmp_path / f"{subdir}_{os.path.basename(path)}"
+        shutil.copyfile(path, copied_file )
+
+        if str(path).endswith(".conda"):
+            package_streaming.stream_conda_component(copied_file, component="info")
 
 def test_package_streaming(conda_paths):
     for path in conda_paths:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Closes https://github.com/conda/conda-package-handling/issues/230

This just makes the component finder a tiny bit smarter in that it ignores common platform patterns when finding these files.

The extracted folder still has these prefixes present, matching the input filename. If you'd prefer that the prefix be stripped from that as well, I can look into it.

I did look at writing a test for this, but it seems like this project doesn't contain testing tarballs/.conda packages, relying instead on using what is already present in the local package cache. If you'd like me to include a test, would it be OK to include a package file in this repo's test folder?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
