### PR TITLE
feat: deal with package servers that reply 416 to too big range requests

### DIFF
--- a/conda_package_streaming/lazy_wheel.py
+++ b/conda_package_streaming/lazy_wheel.py
@@ -46,25 +46,41 @@ class LazyZipOverHTTP:
 
         self._session, self._url, self._chunk_size = session, url, chunk_size
 
+        self._has_streaming_support: bool = True
+        """
+        If the server returns 416 (Range Not Satisfiable), we request the whole file and set
+        this to False. Some package servers (Artifactory) incorrectly respond with 416
+        (Range Not Satisfiable) if the file is smaller than the range requested.
+        """
+
         # initial range request for the end of the file
+        # if the server does not support range requests, this sets _has_streaming_support to False
         tail = self._stream_response(start="", end=CONTENT_CHUNK_SIZE)
         # e.g. {'accept-ranges': 'bytes', 'content-length': '10240',
         # 'content-range': 'bytes 12824-23063/23064', 'last-modified': 'Sat, 16
         # Apr 2022 13:03:02 GMT', 'date': 'Thu, 21 Apr 2022 11:34:04 GMT'}
 
-        if tail.status_code != 206:
+        if self._has_streaming_support and tail.status_code != 206:
             raise HTTPRangeRequestUnsupported("range request is not supported")
 
-        # lowercase content-range to support s3
-        self._length = int(tail.headers["content-range"].partition("/")[-1])
+        if self._has_streaming_support:
+            # lowercase content-range to support s3
+            self._length = int(tail.headers["content-range"].partition("/")[-1])
+        else:
+            # the file is already downloaded
+            self._length = len(tail.content)
+
         self._file = NamedTemporaryFile()
         self.truncate(self._length)
 
         # length is also in Content-Length and Content-Range header
         with self._stay():
-            content_length = int(tail.headers["content-length"])
-            if hasattr(tail, "content"):
-                assert content_length == len(tail.content)
+            if self._has_streaming_support:
+                content_length = int(tail.headers["content-length"])
+                if hasattr(tail, "content"):
+                    assert content_length == len(tail.content)
+            else:
+                content_length = len(tail.content)
             self.seek(self._length - content_length)
             for chunk in tail.iter_content(self._chunk_size):
                 self._file.write(chunk)
@@ -178,16 +194,33 @@ class LazyZipOverHTTP:
     def _stream_response(
         self, start: int | str, end: int, base_headers: dict[str, str] = HEADERS
     ) -> Response:
-        """Return HTTP response to a range request from start to end.
+        """
+        Return HTTP response to a range request from start to end.
+        If the does not support range requests, the whole file is requested.
 
-        :param start: if "", request ``end` bytes from end of file."""
+        :param start: if "", request ``end` bytes from end of file.
+        """
         headers = base_headers.copy()
         headers["Range"] = f"bytes={start}-{end}"
         log.debug("%s", headers["Range"])
         # TODO: Get range requests to be correctly cached
         headers["Cache-Control"] = "no-cache"
         self._request_count += 1
+
+        if self._has_streaming_support:
+            response = self._session.get(self._url, headers=headers, stream=True)
+
+            if response.status_code == 416:
+                # Range Not Satisfiable
+                self._has_streaming_support = False
+            else:
+                response.raise_for_status()
+                return response
+
+        # no streaming support, try to get the whole file
+        del headers["Range"]
         response = self._session.get(self._url, headers=headers, stream=True)
+
         response.raise_for_status()
         return response
 
@@ -214,7 +247,12 @@ class LazyZipOverHTTP:
         self._left[left:right], self._right[left:right] = [start], [end]
 
     def _download(self, start: int, end: int) -> None:
-        """Download bytes from start to end inclusively."""
+        """
+        Download bytes from start to end inclusively. If the server does not support streaming for
+        this file, this does nothing as the entire file is already downloaded.
+        """
+        if not self._has_streaming_support:
+            return
         with self._stay():
             left = bisect_left(self._right, start)
             right = bisect_right(self._left, end)

--- a/conda_package_streaming/lazy_wheel.py
+++ b/conda_package_streaming/lazy_wheel.py
@@ -214,7 +214,7 @@ class LazyZipOverHTTP:
         Return HTTP response to a range request from start to end.
         If the does not support range requests, the whole file is requested.
 
-        :param start: if "", request ``end` bytes from end of file.
+        :param start: if "", request `end` bytes from end of file.
         """
         headers = base_headers.copy()
         headers["Range"] = f"bytes={start}-{end}"

--- a/conda_package_streaming/lazy_wheel.py
+++ b/conda_package_streaming/lazy_wheel.py
@@ -276,8 +276,10 @@ class LazyZipOverHTTP:
         Download bytes from start to end inclusively. If the server does not support streaming for
         this file, this does nothing as the entire file is already downloaded.
         """
-        if not self._has_streaming_support:
-            return
+        # these assertions should hold, but read() violates them
+        # assert 0 <= start <= end
+        # assert end < self._length
+
         with self._stay():
             left = bisect_left(self._right, start)
             right = bisect_right(self._left, end)

--- a/conda_package_streaming/lazy_wheel.py
+++ b/conda_package_streaming/lazy_wheel.py
@@ -51,6 +51,7 @@ class LazyZipOverHTTP:
         If the server returns 416 (Range Not Satisfiable), we request the whole file and set
         this to False. Some package servers (Artifactory) incorrectly respond with 416
         (Range Not Satisfiable) if the file is smaller than the range requested.
+        See https://jfrog.atlassian.net/browse/RTFACT-30882
         """
 
         # initial range request for the end of the file

--- a/conda_package_streaming/test_lazy_wheel.py
+++ b/conda_package_streaming/test_lazy_wheel.py
@@ -1,0 +1,102 @@
+import re
+
+import requests
+import responses
+from requests.models import PreparedRequest
+from responses import matchers
+
+from conda_package_streaming.lazy_wheel import LazyZipOverHTTP
+
+HTTP_FULL_RANGE_PATTERN = re.compile(r"bytes=(\d+)-(\d+)$")
+HTTP_END_RANGE_PATTERN = re.compile(r"bytes=-(\d+)$")
+
+
+class TestLazyZipOverHTTP:
+    @staticmethod
+    def generate_zero_bytes(length_bytes: int) -> bytes:
+        return bytes(length_bytes)
+
+    @staticmethod
+    def successful_http_stream_callback_wrapper(file: bytes):
+        # https://datatracker.ietf.org/doc/html/rfc7233
+        def _callback(request: PreparedRequest):
+            full_pattern_match = HTTP_FULL_RANGE_PATTERN.match(request.headers["Range"])
+            end_pattern_match = HTTP_END_RANGE_PATTERN.match(request.headers["Range"])
+
+            if full_pattern_match:
+                start_range = int(full_pattern_match.group(1))
+                end_range = int(full_pattern_match.group(2))
+
+                assert start_range >= 0
+                assert end_range >= 0
+                assert start_range < end_range
+
+                if start_range >= len(file):
+                    # Range Not Satisfiable
+                    return 416, {}, b""
+
+                # truncate to file length
+                end_range = min(end_range, len(file) - 1)
+                content_length = end_range - start_range + 1  # the bounds are inclusive
+            else:
+                assert end_pattern_match
+
+                content_length_requested = int(end_pattern_match.group(1))
+                assert content_length_requested >= 0
+                content_length = min(content_length_requested, len(file))
+
+                start_range = len(file) - content_length
+                end_range = len(file) - 1
+
+            headers = {
+                "Content-Length": str(content_length),
+                "Content-Range": f"bytes {start_range}-{end_range}/{len(file)}",
+            }
+
+            # this is not inlined because black and flake8 disagree on how to format it
+            end_file_range = end_range + 1
+
+            return 206, headers, file[start_range:end_file_range]
+
+        return _callback
+
+    @responses.activate
+    def test_init_stream_successful(self):
+        responses.add_callback(
+            responses.GET,
+            "https://example.com/test.zip",
+            callback=self.successful_http_stream_callback_wrapper(
+                self.generate_zero_bytes(10000)
+            ),
+            content_type="application/zip",
+        )
+
+        session = requests.Session()
+        lazy_zip = LazyZipOverHTTP("https://example.com/test.zip", session)
+        lazy_zip.read()
+
+    @responses.activate
+    def test_init_stream_retry_without_range(self):
+        """
+        Some package servers (Artifactory) incorrectly respond with 416 (Range Not Satisfiable)
+        when the file is smaller than the range requested.
+        This violates RFC 7233, but we cope with it by retrying without Range, requesting the full
+        file.
+        """
+        responses.add(
+            responses.GET,
+            url="https://example.com/test.zip",
+            status=416,
+            match=[matchers.header_matcher({"Range": re.compile(r".*")})],
+        )
+
+        responses.add(
+            responses.GET,
+            url="https://example.com/test.zip",
+            body=self.generate_zero_bytes(10000),
+            content_type="application/zip",
+        )
+
+        session = requests.Session()
+        lazy_zip = LazyZipOverHTTP("https://example.com/test.zip", session)
+        lazy_zip.read()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ test = [
   "bottle",
   "conda",
   "conda-package-handling >=2",
+  "responses"
 ]
 docs = ["furo", "sphinx", "myst-parser", "mdit-py-plugins>=0.3.0"]
 

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -2,6 +2,7 @@ import io
 import tempfile
 from contextlib import closing, contextmanager
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 from zipfile import ZipFile
 
 import pytest
@@ -125,6 +126,26 @@ def test_lazy_wheel(package_urls):
             break
     else:
         raise LookupError("no .tar.bz2 packages found")
+
+
+@pytest.mark.parametrize("fall_back_to_full_download", [True, False])
+@patch("conda_package_streaming.url.LazyConda")
+def test_conda_reader_for_url_passes_to_lazy_conda_correctly(
+    lazy_conda_mock: MagicMock, fall_back_to_full_download: bool
+):
+    url = "https://example.com/package.conda"
+    session = Session()
+
+    filename, conda = conda_reader_for_url(
+        url, session, fall_back_to_full_download=fall_back_to_full_download
+    )
+
+    assert filename == "package.conda"
+    lazy_conda_mock.assert_called_once_with(
+        url,
+        session,
+        fall_back_to_full_download=fall_back_to_full_download,
+    )
 
 
 def test_no_file_after_info():


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

If using Artifactory as a package server, it incorrectly responds `416 Range Not Satisfiable` to HTTP range requests that request a range larger than the artifact file. This violates RFC 7233 in our opinion, but they are unwilling to fix it.

Therefore, I propose to deal with this situation by re-requesting the entire file without range headers and use that instead if a server ever replies with `416 Range Not Satisfiable`, if possible. Let me know what you think!

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-package-streaming/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-package-streaming/blob/main/CONTRIBUTING.md -->

Cc @pavelzw