### PR TITLE
Skip setting permissions if `tarfile.mode` is `None`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 [//]: # (current developments)
 
+* Skip setting permissions if `tarinfo.mode` is `None`. (#140)
+
 ## 0.11.0 (2024-10)
 
 * Add Python 3.12 to test matrix.

--- a/conda_package_streaming/extract.py
+++ b/conda_package_streaming/extract.py
@@ -20,6 +20,7 @@ HAS_TAR_FILTER = hasattr(tarfile, "tar_filter")
 def extract_stream(
     stream: Generator[tuple[tarfile.TarFile, tarfile.TarInfo]],
     dest_dir: Path | str,
+    tar_filter: str | None = None,
 ):
     """
     Pipe ``stream_conda_component`` output here to extract every member into
@@ -50,7 +51,7 @@ def extract_stream(
             # checked_members().
             tar_args = {"path": dest_dir, "members": checked_members()}
             if HAS_TAR_FILTER:
-                tar_args["filter"] = "fully_trusted"
+                tar_args["filter"] = tar_filter or "fully_trusted"
             tar_file.extractall(**tar_args)
         except OSError as e:
             if e.errno == ELOOP:

--- a/conda_package_streaming/package_streaming.py
+++ b/conda_package_streaming/package_streaming.py
@@ -60,6 +60,9 @@ class TarfileNoSameOwner(tarfile.TarFile):
         Set file permissions of targetpath according to tarinfo, respecting
         umask.
         """
+        if tarinfo.mode is None:
+            return
+
         try:
             os.chmod(targetpath, tarinfo.mode & (-1 & (~self.umask)))
         except OSError as e:

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,12 +1,15 @@
 import io
+import os
 import stat
 import tarfile
 from errno import ELOOP
+from pathlib import Path
 
 import pytest
 
 from conda_package_streaming import exceptions, extract, package_streaming
 
+HAS_TAR_FILTER = hasattr(tarfile, "tar_filter")
 MAX_CONDAS = 8
 
 
@@ -34,15 +37,25 @@ def test_extract_all(conda_paths, tmp_path):
             break
 
 
-def empty_tarfile(name, mode=0o644, tar_mode="w"):
+def empty_tarfile(name, mode=0o644, tar_mode="w", create_subdir=False):
     """
     Return BytesIO containing a tarfile with one empty file named :name
     """
     tar = io.BytesIO()
     t = tarfile.open(mode=tar_mode, fileobj=tar)
-    tarinfo = tarfile.TarInfo(name=name)
-    tarinfo.mode = mode
-    t.addfile(tarinfo, io.BytesIO())
+    if create_subdir:
+        tarinfo = tarfile.TarInfo(name=name)
+        # Add execute bit for directory
+        tarinfo.mode = mode | 0o111
+        tarinfo.type = tarfile.DIRTYPE
+        t.addfile(tarinfo, io.BytesIO())
+        tarinfo = tarfile.TarInfo(name=str(Path(name, name)))
+        tarinfo.mode = mode
+        t.addfile(tarinfo, io.BytesIO())
+    else:
+        tarinfo = tarfile.TarInfo(name=name)
+        tarinfo.mode = mode
+        t.addfile(tarinfo, io.BytesIO())
     t.close()
     tar.seek(0)
     return tar
@@ -125,52 +138,68 @@ def test_chown(conda_paths, tmp_path, mocker):
                 break
 
 
-def test_umask(tmp_path, mocker):
+@pytest.mark.parametrize(
+    "tar_filter",
+    (pytest.param(None, id="no tar filter"), pytest.param("data", id="data_filter")),
+)
+def test_umask(tmp_path, mocker, tar_filter):
     """
     Demonstrate that umask-respecting tar implementation works.
 
     Mock umask in case it is different on your system.
     """
-    MOCK_UMASK = 0o022
-    mocker.patch("conda_package_streaming.package_streaming.UMASK", new=MOCK_UMASK)
+    if tar_filter is not None and not HAS_TAR_FILTER:
+        pytest.skip("Requires tar_filter")
+    current_umask = os.umask(0)
+    try:
+        MOCK_UMASK = 0o022
+        os.umask(MOCK_UMASK)
+        mocker.patch("conda_package_streaming.package_streaming.UMASK", new=MOCK_UMASK)
 
-    assert (
-        package_streaming.TarfileNoSameOwner(fileobj=empty_tarfile("file.txt")).umask
-        == MOCK_UMASK
-    )
+        assert (
+            package_streaming.TarfileNoSameOwner(fileobj=empty_tarfile("file.txt")).umask
+            == MOCK_UMASK
+        )
 
-    # [
-    #   ('S_IFREG', 32768),
-    #   ('UF_HIDDEN', 32768),
-    #   ('FILE_ATTRIBUTE_INTEGRITY_STREAM', 32768)
-    # ]
+        # [
+        #   ('S_IFREG', 32768),
+        #   ('UF_HIDDEN', 32768),
+        #   ('FILE_ATTRIBUTE_INTEGRITY_STREAM', 32768)
+        # ]
 
-    # Of the high bits 100755 highest bit 1 can mean just "is regular file"
+        # Of the high bits 100755 highest bit 1 can mean just "is regular file"
 
-    tar3 = empty_tarfile(name="naughty_umask", mode=0o777)
+        name = "naughty_umask"
+        files_to_check = [tmp_path / name, tmp_path / name / name]
+        tar3 = empty_tarfile(name=name, mode=0o777, create_subdir=True)
 
-    stat_check = stat.S_IRGRP
-    stat_name = "S_IRGRP"
+        stat_check = stat.S_IRGRP
+        stat_name = "S_IRGRP"
 
-    extract.extract_stream(stream_stdlib(tar3), tmp_path)
-    mode = (tmp_path / "naughty_umask").stat().st_mode
-    # is the new .extractall(filter=) erasing group-writable?
-    assert mode & stat.S_IRGRP, f"Has {stat_name}? %o != %o" % (
-        mode,
-        mode & stat_check,
-    )
+        extract.extract_stream(stream_stdlib(tar3), tmp_path, tar_filter=tar_filter)
+        for file in files_to_check:
+            mode = file.stat().st_mode
+            # is the new .extractall(filter=) erasing group-writable?
+            assert mode & stat_check, f"{file} has {stat_name}? %o != %o" % (
+                mode,
+                mode & stat_check,
+            )
 
-    # specifically forbid that stat bit
-    MOCK_UMASK |= stat_check
-    mocker.patch("conda_package_streaming.package_streaming.UMASK", new=MOCK_UMASK)
+        # specifically forbid that stat bit
+        MOCK_UMASK |= stat_check
+        mocker.patch("conda_package_streaming.package_streaming.UMASK", new=MOCK_UMASK)
+        os.umask(MOCK_UMASK)
 
-    tar3.seek(0)
-    extract.extract_stream(stream(tar3), tmp_path)
-    mode = (tmp_path / "naughty_umask").stat().st_mode
-    assert not mode & stat_check, f"No {stat_name} due to umask? %o != %o" % (
-        mode,
-        mode & stat_check,
-    )
+        tar3.seek(0)
+        extract.extract_stream(stream(tar3), tmp_path, tar_filter=tar_filter)
+        for file in files_to_check:
+            mode = file.stat().st_mode
+            assert not (mode & stat_check), f"{file}: No {stat_name} due to umask? %o != %o" % (
+                mode,
+                mode & stat_check,
+            )
+    finally:
+        os.umask(current_umask)
 
 
 def test_encoding():


### PR DESCRIPTION
### Description

Python's `tarfile` module supports filters that can set `tarinfo.mode` to `None`. One such example is the `data` filter: https://github.com/python/cpython/blob/v3.12.9/Lib/tarfile.py#L784-L786

The CPYthon module returns without touching the permissions in this case: https://github.com/python/cpython/blob/v3.12.9/Lib/tarfile.py#L2596-L2604

`TarfileNoSameOwner`, however, does not, which causes it to fail if the data filter is set. This PR ports the behavior of the CPython behavior.

In order to test that umask is still respected, I had to add a `filter` argument to the `extract_stream` function and create a subdirectory in the test tarfile.

Closes #139.