### PR TITLE
Accept pre-opened `ZipFile` via `zf=` kwarg on `stream_conda_component` (B13)

### DIFF
--- a/conda_package_streaming/package_streaming.py
+++ b/conda_package_streaming/package_streaming.py
@@ -117,6 +117,7 @@ def stream_conda_component(
     component: CondaComponent | str = CondaComponent.pkg,
     *,
     encoding="utf-8",
+    zf: zipfile.ZipFile | None = None,
 ) -> Generator[tuple[tarfile.TarFile, tarfile.TarInfo]]:
     """
     Yield members from .conda's embedded {component}- tarball. "info" or "pkg".
@@ -130,12 +131,19 @@ def stream_conda_component(
     first result and then ignore the rest of this generator. ``extractall`` takes
     care of some directory permissions/mtime issues, compared to ``extract`` or
     writing out the file objects yourself.
+
+    ``zf``: an optional pre-opened ``zipfile.ZipFile`` for .conda
+    archives. Callers that stream both the ``pkg`` and ``info``
+    components (e.g. ``conda_package_handling.streaming._stream_components``)
+    can open the zip once and pass it in both times, avoiding the
+    duplicate central-directory parse. See #173.
     """
     if str(filename).endswith(".conda"):
         if zstandard is None:
             raise RuntimeError("Cannot unpack `.conda` without zstandard")
 
-        zf = zipfile.ZipFile(fileobj or filename)
+        if zf is None:
+            zf = zipfile.ZipFile(fileobj or filename)
         stem, _, _ = os.path.basename(filename).rpartition(".")
         component_name = f"{component}-{stem}"
         component_filename = [

--- a/conda_package_streaming/package_streaming.py
+++ b/conda_package_streaming/package_streaming.py
@@ -132,11 +132,18 @@ def stream_conda_component(
     care of some directory permissions/mtime issues, compared to ``extract`` or
     writing out the file objects yourself.
 
-    ``zf``: an optional pre-opened ``zipfile.ZipFile`` for .conda
-    archives. Callers that stream both the ``pkg`` and ``info``
-    components (e.g. ``conda_package_handling.streaming._stream_components``)
-    can open the zip once and pass it in both times, avoiding the
-    duplicate central-directory parse. See #173.
+    Args:
+        filename: path or file-like object to the .conda or .tar.bz2 file
+
+        component: "pkg" or "info" component to extract
+
+        encoding: "utf-8" passed to TarFile.open(); can be changed for testing.
+
+        zf: optional pre-opened ``zipfile.ZipFile`` for .conda archives.
+            When provided, reuses the already-opened ZipFile instead of
+            parsing the central directory again. Callers that stream both
+            the ``pkg`` and ``info`` components can open the zip once and
+            pass it in both times, avoiding duplicate parsing. See #173.
     """
     if str(filename).endswith(".conda"):
         if zstandard is None:


### PR DESCRIPTION
### Description

`stream_conda_component` (`conda_package_streaming/package_streaming.py:138`) instantiates `zipfile.ZipFile(fileobj)` on every call. Callers in `conda-package-handling.streaming._extract` iterate over the two components (`pkg` and `info`) of a `.conda` archive, so the ZIP central-directory end-of-file record is parsed twice per package during an install.

This PR adds an optional `zf=` kwarg: when callers pass an already-opened `ZipFile`, `stream_conda_component` reuses it instead of parsing from scratch. Backward compatible — default behavior is unchanged.

Companion PR in conda-package-handling (https://github.com/conda/conda-package-handling/pull/318) is the consumer that threads a single `ZipFile` through both components. Both together give the 2× speedup below; this PR alone is a no-op improvement because the existing callers ignore the new kwarg.

Part of the [conda-tempo Track B](https://github.com/jezdez/conda-tempo) performance work. Tracking issue: conda/conda#15969.

**Phase-2 micro-benchmark** ([bench_s13_zipfile_single.py](https://github.com/jezdez/conda-tempo/blob/main/bench/phase2/bench_s13_zipfile_single.py), 10 `.conda` archives, both components):

| | Before | After | Speedup |
|---|---:|---:|---:|
| 10 archives, 2 components each | 999 µs | 502 µs | **2×** |

**Phase-4 end-to-end** (as part of the cps stack with B14 + B20):

| Workload | mac baseline → stacked | Linux baseline → stacked |
|---|---|---|
| W4 (cold-cache data-sci install) | 43.88 s → 36.14 s | 26.28 s → 23.38 s |

Full research report: https://github.com/jezdez/conda-tempo/blob/main/track-b-transaction.md