### PR TITLE
Skip `utime` in `TarfileNoSameOwner` (B14)

### DIFF
--- a/conda_package_streaming/package_streaming.py
+++ b/conda_package_streaming/package_streaming.py
@@ -55,6 +55,18 @@ class TarfileNoSameOwner(tarfile.TarFile):
         """
         return
 
+    def utime(self, tarinfo, targetpath):
+        """
+        Override utime to be a no-op. conda packages' tarinfo mtime is
+        canonicalised to a constant at build time via
+        ``conda_package_handling.utils.anonymize_tarinfo``, so preserving
+        it on disk yields no observable information. stdlib tarfile's
+        per-member ``os.utime`` call was ~5 % of extract wall time on a
+        typical scientific-Python env (141 ms / 3080 ms total, 6268 calls
+        in the measured profile). Skip it. See #174.
+        """
+        return
+
     def chmod(self, tarinfo, targetpath):
         """
         Set file permissions of targetpath according to tarinfo, respecting


### PR DESCRIPTION
### Description

`TarfileNoSameOwner.utime` preserves the tar member's mtime on disk. For conda packages this is wasted work: `conda-build` canonicalises all tar mtimes to a constant at build time (`anonymize_tarinfo`), so the on-disk mtime encodes no user-meaningful information — every file in a given conda package gets the same timestamp.

This PR makes `TarfileNoSameOwner.utime` a no-op, mirroring the existing `chown` no-op on the same class. Saves one `utimensat` syscall per extracted member.

Part of the [conda-tempo Track B](https://github.com/jezdez/conda-tempo) performance work. Tracking issue: conda/conda#15969.

**Extract cProfile** (3 real scientific-Python `.conda` archives, 6 268 tar members, macOS APFS):

| Call | tottime | calls | % of wall |
|---|---:|---:|---:|
| `posix.utime` | 141 ms | 6 268 | **5 %** |

That's 5 % of the whole extract attributable to preserving mtimes that are all identical to begin with.

**Phase-2 micro-benchmark** ([S15 fixture](https://github.com/jezdez/conda-tempo/blob/main/bench/phase2/bench_s15_cph_api.py), 5-package extract):

| | Before | After | Δ |
|---|---:|---:|---:|
| Total extract wall time | 3.78 s | 3.65 s | **−3.4 %** |

**Phase-4 end-to-end** (as part of the cps stack with B13 + B20):

| Workload | mac baseline → stacked | Linux baseline → stacked |
|---|---|---|
| W4 (cold-cache data-sci install) | 43.88 s → 36.14 s | 26.28 s → 23.38 s |

Full research report: https://github.com/jezdez/conda-tempo/blob/main/track-b-transaction.md