### PR TITLE
Hybrid fast/fallback per-member safety check (B20)

### DIFF
--- a/conda_package_streaming/extract.py
+++ b/conda_package_streaming/extract.py
@@ -46,6 +46,12 @@ def extract_stream(
     except FileNotFoundError:
         # ``extractall`` will create ``dest_dir`` for us.
         dest_dir_was_empty = True
+    except OSError:
+        # ``dest_dir`` exists but isn't readable as a directory
+        # (regular file, permission denied, etc.). Be conservative —
+        # take the fallback for the whole stream, and let
+        # ``extractall`` surface the canonical error.
+        dest_dir_was_empty = False
 
     # Per-member safety check. Historically this called
     # ``os.path.realpath(os.path.join(dest_dir, name))`` which walks the

--- a/conda_package_streaming/extract.py
+++ b/conda_package_streaming/extract.py
@@ -32,6 +32,21 @@ def extract_stream(
     dest_dir = os.path.realpath(dest_dir)
     dest_dir_with_sep = dest_dir if dest_dir.endswith(os.sep) else dest_dir + os.sep
 
+    # The fast path's safety claim relies on the filesystem tree under
+    # ``dest_dir`` containing only paths *we* created — which is only
+    # true when ``dest_dir`` was empty when extract started. If a caller
+    # hands us a ``dest_dir`` that already contains a symlink, a member
+    # whose name traverses through that pre-existing symlink would
+    # escape under the string-only check. We do one ``scandir`` call up
+    # front; if anything is in there already, we conservatively start
+    # the entire stream in fallback mode.
+    try:
+        with os.scandir(dest_dir) as it:
+            dest_dir_was_empty = next(it, None) is None
+    except FileNotFoundError:
+        # ``extractall`` will create ``dest_dir`` for us.
+        dest_dir_was_empty = True
+
     # Per-member safety check. Historically this called
     # ``os.path.realpath(os.path.join(dest_dir, name))`` which walks the
     # joined path and issues one ``lstat`` per path component — roughly
@@ -52,25 +67,26 @@ def extract_stream(
     # redirect writes outside ``dest_dir``.
     #
     # Across the full macOS conda-forge package cache (186 archives,
-    # 30 299 members, 1 274 symlinks), 81 % of members extract via the
+    # 30,299 members, 1,274 symlinks), 81 % of members extract via the
     # fast path and 142 / 186 archives never trigger the fallback. See
     # #175 for the compatibility survey and before/after numbers.
     for tar_file, _ in stream:
 
         def checked_members():
-            seen_risky = False
+            seen_risky = not dest_dir_was_empty
             for member in tar_file:
                 name = member.name
                 if not seen_risky:
-                    # is this member itself risky, or does its name itself
-                    # require the full realpath check?
-                    split_parts = name.replace("\\", "/").split("/")
+                    # In tar, member names are always ``/``-separated
+                    # (POSIX 1003.1) and ``tarfile`` exposes them
+                    # verbatim, so a single ``split("/")`` is enough
+                    # on every platform.
                     if (
                         member.issym()
                         or member.islnk()
                         or name.startswith("/")
                         or name.startswith(os.sep)
-                        or ".." in split_parts
+                        or ".." in name.split("/")
                     ):
                         seen_risky = True
 
@@ -80,6 +96,7 @@ def extract_stream(
                         dest_dir_with_sep,
                     )
                 else:
+                    # ``join`` + ``normpath`` are pure string ops, no syscalls.
                     normalized = os.path.normpath(os.path.join(dest_dir, name))
                     ok = normalized == dest_dir or normalized.startswith(
                         dest_dir_with_sep,

--- a/conda_package_streaming/extract.py
+++ b/conda_package_streaming/extract.py
@@ -30,25 +30,68 @@ def extract_stream(
     for ``.tar.bz2`` every member is extracted.
     """
     dest_dir = os.path.realpath(dest_dir)
+    dest_dir_with_sep = dest_dir if dest_dir.endswith(os.sep) else dest_dir + os.sep
 
-    def is_within_dest_dir(name):
-        abs_target = os.path.realpath(os.path.join(dest_dir, name))
-        prefix = os.path.commonpath((dest_dir, abs_target))
-        return prefix == dest_dir
-
+    # Per-member safety check. Historically this called
+    # ``os.path.realpath(os.path.join(dest_dir, name))`` which walks the
+    # joined path and issues one ``lstat`` per path component — roughly
+    # 15 lstats per member on scientific-Python archives, which works
+    # out to the single largest contributor to extract wall time after
+    # the raw file I/O.
+    #
+    # We split the check into a fast path and a fallback. For a member
+    # whose name contains no ``..`` and no absolute-path prefix, and
+    # while the archive has so far yielded only regular files and
+    # directories, a pure string-based ``normpath`` + ``startswith``
+    # check is provably equivalent to ``realpath`` — the filesystem
+    # tree under ``dest_dir`` contains only paths we created, so no
+    # symlinks are there to traverse. Once we encounter a member that
+    # is a symlink, hardlink, absolute-path, or ``..``-containing,
+    # subsequent members fall back to the full ``realpath`` check
+    # because the extracted tree may now contain symlinks that could
+    # redirect writes outside ``dest_dir``.
+    #
+    # Across the full macOS conda-forge package cache (186 archives,
+    # 30 299 members, 1 274 symlinks), 81 % of members extract via the
+    # fast path and 142 / 186 archives never trigger the fallback. See
+    # #175 for the compatibility survey and before/after numbers.
     for tar_file, _ in stream:
-        # careful not to seek backwards
+
         def checked_members():
-            # from conda_package_handling
+            seen_risky = False
             for member in tar_file:
-                if not is_within_dest_dir(member.name):
-                    raise exceptions.SafetyError(f"contains unsafe path: {member.name}")
+                name = member.name
+                if not seen_risky:
+                    # is this member itself risky, or does its name itself
+                    # require the full realpath check?
+                    split_parts = name.replace("\\", "/").split("/")
+                    if (
+                        member.issym()
+                        or member.islnk()
+                        or name.startswith("/")
+                        or name.startswith(os.sep)
+                        or ".." in split_parts
+                    ):
+                        seen_risky = True
+
+                if seen_risky:
+                    abs_target = os.path.realpath(os.path.join(dest_dir, name))
+                    ok = abs_target == dest_dir or abs_target.startswith(
+                        dest_dir_with_sep,
+                    )
+                else:
+                    normalized = os.path.normpath(os.path.join(dest_dir, name))
+                    ok = normalized == dest_dir or normalized.startswith(
+                        dest_dir_with_sep,
+                    )
+
+                if not ok:
+                    raise exceptions.SafetyError(
+                        f"contains unsafe path: {name}",
+                    )
                 yield member
 
         try:
-            # Drop checked_members() when HAS_TAR_FILTER once we are 100%
-            # certain the stdlib filter maintains same permissions as
-            # checked_members().
             tar_args = {"path": dest_dir, "members": checked_members()}
             if HAS_TAR_FILTER:
                 tar_args["filter"] = tar_filter or "fully_trusted"
@@ -58,7 +101,7 @@ def extract_stream(
                 raise exceptions.CaseInsensitiveFileSystemError() from e
             raise
 
-        # next iteraton of for loop raises GeneratorExit in stream
+        # next iteration of for loop raises GeneratorExit in stream
         stream.close()
 
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -125,6 +125,31 @@ def test_slip(tmp_path):
         extract.extract_stream(stream(tar2), tmp_path)
 
 
+@pytest.mark.skipif(
+    not hasattr(os, "symlink"), reason="platform does not support symlinks"
+)
+def test_slip_through_pre_existing_symlink(tmp_path):
+    """
+    The fast path is only sound for an initially-empty ``dest_dir``. If a
+    caller hands us a ``dest_dir`` that already contains a symlink, a
+    member whose name traverses through that symlink would otherwise
+    escape under the string-only check; entry-time scandir must flip us
+    into fallback mode for the whole stream so ``realpath`` catches it.
+    """
+    dest_dir = tmp_path / "dest"
+    dest_dir.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    # Pre-existing symlink under dest_dir pointing OUT of dest_dir.
+    os.symlink(outside, dest_dir / "foo")
+
+    # Member whose name traverses the pre-existing ``foo`` symlink.
+    tar = empty_tarfile(name="foo/escape")
+
+    with pytest.raises(exceptions.SafetyError):
+        extract.extract_stream(stream(tar), dest_dir)
+
+
 def test_chown(conda_paths, tmp_path):
     for package in conda_paths[:2]:
         print(package)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -150,6 +150,23 @@ def test_slip_through_pre_existing_symlink(tmp_path):
         extract.extract_stream(stream(tar), dest_dir)
 
 
+def test_dest_dir_is_a_regular_file(tmp_path):
+    """
+    A ``dest_dir`` that exists but is a regular file should propagate the
+    canonical error from ``extractall`` rather than from the entry-time
+    scandir guard. The scandir branch swallows ``OSError`` and falls
+    through, so the user-visible message is unchanged from the pre-B20
+    behaviour.
+    """
+    not_a_dir = tmp_path / "regular_file"
+    not_a_dir.write_text("not a directory")
+
+    tar = empty_tarfile(name="any_member")
+
+    with pytest.raises((NotADirectoryError, FileExistsError)):
+        extract.extract_stream(stream(tar), not_a_dir)
+
+
 def test_chown(conda_paths, tmp_path):
     for package in conda_paths[:2]:
         print(package)


### PR DESCRIPTION
### Description

The per-member path-safety check in `extract_stream` currently calls `os.path.realpath(os.path.join(dest_dir, member.name))` plus `os.path.commonpath(...)` on every tar member. On a roughly 30,000-member scientific-Python environment, that path-resolution walk is a hot loop on top of extraction work that is otherwise syscall-bound.

A string-only check (`normpath` plus `startswith`) is faster but has a security regression: it misses symlink-chain traversal attacks. If one member creates a symlink under `dest_dir` pointing outside the destination, a later apparently-normalized member can follow that symlink out of `dest_dir`.

This PR uses a hybrid path:

- Pre-check `dest_dir` once with `os.scandir`. If it is missing or empty, extraction can start on the fast path. If it already contains entries or cannot be scanned as a directory, start conservatively in fallback mode.
- Track a per-stream `seen_risky` flag, initialized from that `dest_dir` check.
- While `seen_risky` is `False`, use the string-only fast path (`normpath` plus `startswith`). The tree is empty or created by this extraction stream, and no risky member has been seen.
- The first symlink, hardlink, absolute member name, or `..` member name switches the rest of the stream to the existing `realpath`-based check.

Safety remains aligned with the pre-B20 all-`realpath` behavior: the fast path is used only while the destination tree is known to be empty or owned by this extraction stream and no risky member has been seen; all other cases use the existing `realpath` check. An audit of 186 conda-forge archives (30,299 members, 1,274 symlinks, no rejected archives) found that 81% of members use the fast path and 142 archives never trigger fallback.

This subsumes the earlier B12 destination-directory memoization branch; the string fast path is faster than that proposal.

Part of the [conda-tempo Track B](https://github.com/jezdez/conda-tempo) performance work. Tracking issue: conda/conda#15969.

### Focused archive-extraction measurement

Five real scientific-Python `.conda` archives, using the same S16 fixture as the py-rattler comparison:

| | cps main | cps plus B20 | filter="data" | py-rattler |
|---|---:|---:|---:|---:|
| macOS APFS | 3.71 s | 3.63 s | 3.96 s | 3.67 s |
| Linux ext4 | 2.88 s | 2.23 s | 2.68 s | 2.38 s |

These are archive-extraction measurements, not current whole-conda-transaction claims. On the Linux fixture B20 is 22.6% faster than cps main and 6.3% faster than py-rattler. The earlier full-stack W4 table was removed because it included dropped B14 and no longer describes a mergeable Track B combination.

Full research report: https://github.com/jezdez/conda-tempo/blob/main/track-b-transaction.md
